### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,18 @@
     "dev": "nodemon server.js"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-rate-limit": "^7.5.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"
   },
-  "keywords": ["demo", "animation", "business", "website"],
+  "keywords": [
+    "demo",
+    "animation",
+    "business",
+    "website"
+  ],
   "author": "",
   "license": "MIT"
 }

--- a/server.js
+++ b/server.js
@@ -1,9 +1,17 @@
 const express = require('express');
 const path = require('path');
+const rateLimit = require('express-rate-limit');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+// Rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // Limit each IP to 100 requests per windowMs
+});
+
+app.use(limiter);
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.get('/', (req, res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/dpark2025/democard/security/code-scanning/1](https://github.com/dpark2025/democard/security/code-scanning/1)

To address the issue, we will add a rate-limiting middleware to the application using the `express-rate-limit` package. This middleware will be applied globally to all routes, including the `app.get('/')` route, to limit the number of requests a client can make within a specific time window.

Steps:
1. Install and import the `express-rate-limit` package.
2. Define a rate limiter with appropriate settings, such as allowing a maximum of 100 requests per 15 minutes.
3. Apply the rate limiter as middleware to the Express application using `app.use()`.

This fix ensures that the application is protected against abuse by limiting the rate of incoming requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
