### PR TITLE
Remove corrupted modplayer.js file

### DIFF
--- a/public/js/lib/modplayer.js
+++ b/public/js/lib/modplayer.js
@@ -1,1 +1,0 @@
-404: Not Found


### PR DESCRIPTION
## Summary
- Removed corrupted `public/js/lib/modplayer.js` file that contained only "404: Not Found"
- File was not referenced anywhere in the codebase, making it safe to remove

## Background
The file `public/js/lib/modplayer.js` appears to have been corrupted, containing only the text "404: Not Found" instead of actual JavaScript code. This likely happened when the file was fetched from a server that returned an HTTP 404 error response instead of the expected file content.

## Changes Made
- ✅ Removed `public/js/lib/modplayer.js`
- ✅ Verified the file is not referenced anywhere in the codebase (no imports, requires, or script tags)
- ✅ Confirmed other mod player files exist (bassoonplayer-min.js, pt.js) and are intact

## Review Notes
- **Safety**: The file removal is safe as it's not used anywhere in the project
- **Alternative**: If modplayer.js functionality is needed in the future, a proper working version can be added
- **Impact**: Zero impact on existing functionality since the file was corrupted and unused

## Test Plan
- [x] Verified no references to modplayer.js in the codebase
- [x] Confirmed application builds and runs without the file
- [x] Other mod player files remain functional

Fixes #4

Generated with [Claude Code](https://claude.ai/code)